### PR TITLE
Update TypeScript and TRPC versions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "@tauri-apps/plugin-process": "~2",
     "@tauri-apps/plugin-updater": "~2",
     "@tauri-apps/plugin-upload": "^2.2.1",
-    "@trpc/client": "^11.1.0",
+    "@trpc/client": "^11.4.3",
     "@types/nprogress": "^0.2.3",
     "boring-avatars": "^1.11.2",
     "canvas-confetti": "^1.9.3",
@@ -97,7 +97,7 @@
     "cross-env": "^7.0.3",
     "tailwindcss": "^4.1.4",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "~5.6.2",
+    "typescript": "^5.8.3",
     "vite": "^6.0.3"
   }
 }

--- a/app/tauri-plugin-blinko/package.json
+++ b/app/tauri-plugin-blinko/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",
     "rollup": "^4.9.6",
-    "typescript": "^5.3.3",
+    "typescript": "^5.8.3",
     "tslib": "^2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "concurrently": "^9.1.2",
     "eslint": "^8.56.0",
     "prettier": "^3.2.5",
-    "typescript": "^5.1.6",
+    "typescript": "^5.8.3",
     "vite-plugin-pwa": "^1.0.0",
     "workbox-window": "^7.3.0"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -22,17 +22,13 @@
     "@langchain/community": "^0.3.40",
     "@libsql/client": "^0.15.4",
     "@libsql/core": "^0.15.4",
-    "@libsql/linux-arm64-gnu": "0.5.8",
-    "@libsql/linux-arm64-musl": "0.5.8",
-    "@libsql/linux-x64-gnu": "0.5.8",
-    "@libsql/linux-x64-musl": "0.5.8",
     "@mastra/core": "^0.8.2",
     "@mastra/rag": "^0.1.17",
     "@openrouter/ai-sdk-provider": "^0.4.5",
     "@prisma/client": "^5.22.0",
     "@prisma/engines": "^6.5.0",
     "@tavily/core": "^0.3.7",
-    "@trpc/server": "11.1.0",
+    "@trpc/server": "11.4.3",
     "@types/express": "^5.0.1",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
@@ -77,7 +73,7 @@
     "superjson": "^2.2.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "trpc-to-openapi": "^2.0.2",
+    "trpc-to-openapi": "^2.3.2",
     "unfurl.js": "^6.4.0",
     "vite-express": "^0.20.0",
     "voyage-ai-provider": "^1.0.1",
@@ -115,6 +111,12 @@
     "prettier": "^3.2.5",
     "prisma": "5.21.1",
     "tsup": "^8.4.0",
-    "typescript": "^5.1.6"
+    "typescript": "^5.8.3"
+  },
+  "optionalDependencies": {
+    "@libsql/linux-arm64-gnu": "0.5.8",
+    "@libsql/linux-arm64-musl": "0.5.8",
+    "@libsql/linux-x64-gnu": "0.5.8",
+    "@libsql/linux-x64-musl": "0.5.8"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade TypeScript to 5.8.3 across packages
- upgrade `@trpc/server` and `@trpc/client` to 11.4.3
- update `trpc-to-openapi` to 2.3.2
- move libsql platform packages to optionalDependencies

## Testing
- `npm install --legacy-peer-deps --unsafe-perm --force` *(fails: blocked by binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_6886843df98c8331bbafbebca75f6fdb