### PR TITLE
Add dynamic libsql detection for ARMv7

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Remove or disable the swap file afterwards if you no longer need it.
 
 The Dockerfile also limits Node's heap via `NODE_OPTIONS=--max-old-space-size=512` to avoid out-of-memory errors. For large builds you can split steps or use a `package-lock.json` with `npm ci` to freeze dependencies and lower RAM usage.
 
+### ARMv7 and libsql
+
+`libsql` does not provide prebuilt binaries for the 32‑bit ARMv7 architecture used by the Raspberry Pi 3. The package is now optional and the build skips it on ARMv7.
+This means vector search features that rely on `libsql` are disabled on these devices.
+At runtime Blinkō detects the missing module and logs `⚠️ libsql no disponible: vector search deshabilitado en ARMv7`.
+
 ## 👨🏼‍💻Contribution
 Contributions are the heart of what makes the open-source community so dynamic, creative, and full of learning opportunities. Your involvement helps drive innovation and growth. We deeply value any contribution you make, and we're excited to have you as part of our community. Thank you for your support! 🙌
 

--- a/dockerfile
+++ b/dockerfile
@@ -111,7 +111,9 @@ RUN echo "Installing additional dependencies..." && \
     npm install -g prisma@5.21.1 && \
     npm install sqlite3@5.1.7 && \
     npm install llamaindex @langchain/community@0.3.40 && \
-    npm install @libsql/client @libsql/core && \
+    # libsql only ships arm64/x64 binaries; install fails on armv7 so it's optional
+    # the application detects absence of libsql at runtime and disables vector search
+    npm install @libsql/client @libsql/core || true && \
     npx prisma generate && \
     # find / -type d -name "onnxruntime-*" -exec rm -rf {} + 2>/dev/null || true && \
     # npm cache clean --force && \

--- a/server/aiServer/vector/sqlite3.ts
+++ b/server/aiServer/vector/sqlite3.ts
@@ -1,4 +1,18 @@
-import Database from "libsql";
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+let Database: any;
+try {
+  // Dynamically require libsql so missing binaries on ARMv7 don't crash
+  Database = require("libsql");
+} catch (e) {
+  console.warn(
+    '⚠️ libsql no disponible: vector search deshabilitado en ARMv7',
+  );
+}
+
+// Export flag so callers can detect if libsql loaded correctly
+export const hasLibsql = Boolean(Database);
 import { Buffer } from "node:buffer";
 
 import type {
@@ -33,6 +47,9 @@ export function createClient(config: Config): Client {
 
 /** @private */
 export function _createClient(config: ExpandedConfig): Client {
+  if (!Database) {
+    throw new Error('libsql module not available on this architecture.');
+  }
   if (config.scheme !== "file") {
     throw new LibsqlError(
       `URL scheme ${JSON.stringify(config.scheme + ":")} is not supported by the local sqlite3 client. ` +

--- a/server/package.json
+++ b/server/package.json
@@ -114,6 +114,7 @@
     "typescript": "^5.8.3"
   },
   "optionalDependencies": {
+    "libsql": "0.4.7",
     "@libsql/linux-arm64-gnu": "0.5.8",
     "@libsql/linux-arm64-musl": "0.5.8",
     "@libsql/linux-x64-gnu": "0.5.8",


### PR DESCRIPTION
## Summary
- add runtime flag in `sqlite3.ts` for libsql availability
- disable vector DB features when libsql is missing
- warn users that vector search is disabled on ARMv7
- document ARMv7 behaviour and Dockerfile instructions

## Testing
- `npm run build:blinko:types` *(fails: Cannot find modules)*
- `npm install --legacy-peer-deps --unsafe-perm` *(fails: blocked binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68875361fd808331a460c6d7959fe867