### PR TITLE
Make libsql fully optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+### Changelog
+
+- make `libsql` install optional to support ARMv7
+- dynamic require avoids crashes when library is missing
+- Dockerfile installs `libsql` with failure allowed
+

--- a/dockerfile
+++ b/dockerfile
@@ -113,7 +113,7 @@ RUN echo "Installing additional dependencies..." && \
     npm install llamaindex @langchain/community@0.3.40 && \
     # libsql only ships arm64/x64 binaries; install fails on armv7 so it's optional
     # the application detects absence of libsql at runtime and disables vector search
-    npm install @libsql/client @libsql/core || true && \
+    npm install @libsql/client @libsql/core libsql || true && \
     npx prisma generate && \
     # find / -type d -name "onnxruntime-*" -exec rm -rf {} + 2>/dev/null || true && \
     # npm cache clean --force && \


### PR DESCRIPTION
## Summary
- install libsql in Dockerfile but ignore failure so ARMv7 builds succeed
- add short changelog describing optional libsql handling

## Testing
- `env npm_config_arch=arm npm install --ignore-scripts --legacy-peer-deps`

------
https://chatgpt.com/codex/tasks/task_e_688829203d4c83318fa07357e37218ba