### PR TITLE
Remove dumb-init from Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         platforms: linux/arm/v7
         tags: ${{ secrets.DOCKER_USERNAME }}/blinko:armv7
         cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Move cache for future runs
       run: |

--- a/dockerfile
+++ b/dockerfile
@@ -80,7 +80,7 @@ RUN --mount=type=cache,target=/root/.npm \
     fi && \
     chmod +x ./start.sh && \
     ls -la start.sh && \
-    if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "armv7l" ]
+    if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "armv7l" ]; then \
         echo "Detected ARM architecture, installing sharp platform-specific dependencies..." && \
         mkdir -p /tmp/sharp-cache && \
         export SHARP_CACHE_DIRECTORY=/tmp/sharp-cache && \

--- a/dockerfile
+++ b/dockerfile
@@ -80,7 +80,7 @@ RUN --mount=type=cache,target=/root/.npm \
     fi && \
     chmod +x ./start.sh && \
     ls -la start.sh && \
-    if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then \
+    if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "armv7l" ]
         echo "Detected ARM architecture, installing sharp platform-specific dependencies..." && \
         mkdir -p /tmp/sharp-cache && \
         export SHARP_CACHE_DIRECTORY=/tmp/sharp-cache && \


### PR DESCRIPTION
## Summary
- drop dumb-init downloader stage
- execute `start.sh` directly
- target ARMv7 for build and runtime
- combine setup steps and use BuildKit cache for npm

## Testing
- `npm test`
- `wget --spider` on nonexistent dumb-init URL
- `apt-get update` *(fails: 403 Forbidden for mise.jdx.dev)*

------
https://chatgpt.com/codex/tasks/task_e_688abc5ab1e483318b6eefb89e8ea84c